### PR TITLE
Remove Yelp cached data method

### DIFF
--- a/src/core/assessment.py
+++ b/src/core/assessment.py
@@ -134,9 +134,8 @@ def make(user_details: dict) -> str:
         "price": "1,2,3,4"
     }
 
-    # Get a response from the Yelp API
-    # and find the closest restaurant
-    r = yelp.make_cached_request(url_params)
+    # Get a response from the Yelp API and find the closest restaurant
+    r = yelp.make_request(url_params)
     restaurant = __get_closest_restaurant(r)
 
     # ...Except Yelp couldn't find a restaurant we might be at

--- a/src/core/yelp.py
+++ b/src/core/yelp.py
@@ -67,18 +67,3 @@ class Yelp:
         if r.status_code == requests.codes.ok:
             return r.json()
         return no_request_response
-
-    def make_cached_request(self, url_params: dict) -> list:
-        # TODO Delete method
-        print("**** `make_cached_request` is only for development use! ****")
-
-        if os.path.exists("data.json"):
-            print("Returning cached data")
-            with open("data.json", "rt") as f:
-                data = f.read()
-            return json.loads(data)
-
-        data = self.make_request(url_params)
-        with open("data.json", "wt") as f:
-            f.write(json.dumps(data, indent=2))
-        return data


### PR DESCRIPTION
Remove `Yelp.make_cached_request` method. It was only to be used during development.